### PR TITLE
Fix mobile assistant widget scaling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -563,3 +563,18 @@ h3 {
         bottom: 1rem;
     }
 }
+
+/* Extra-shrink assistant on very narrow phones (typ. 360px CSS width) so the hero
+   terminal stays readable; iPhone 15 class (~390px) still uses rules above. */
+@media (max-width: 400px) {
+    .clippy-container {
+        --clippy-mobile-size: clamp(70px, 19vw, 102px);
+        --clippy-mobile-gap: 0.4rem;
+    }
+
+    .clippy-bubble {
+        max-width: min(200px, calc(100vw - 2rem - var(--clippy-mobile-size) - var(--clippy-mobile-gap)));
+        padding: 0.65rem 0.75rem;
+        font-size: clamp(0.68rem, 3.2vw, 0.78rem);
+    }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -532,4 +532,34 @@ h3 {
     .terminal-text {
         text-overflow: ellipsis;
     }
+
+    .clippy-container {
+        --clippy-mobile-size: clamp(84px, 24vw, 116px);
+        --clippy-mobile-gap: 0.5rem;
+        gap: var(--clippy-mobile-gap);
+        right: -100vw;
+        bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+        max-width: calc(100vw - 2rem);
+    }
+
+    .clippy-container.active {
+        right: 1rem;
+    }
+
+    .clippy {
+        width: var(--clippy-mobile-size);
+        height: auto;
+    }
+
+    .clippy-bubble {
+        max-width: min(240px, calc(100vw - 2rem - var(--clippy-mobile-size) - var(--clippy-mobile-gap)));
+        padding: 0.75rem 0.85rem;
+        border-radius: 0.9rem;
+        font-size: clamp(0.72rem, 2.7vw, 0.82rem);
+        line-height: 1.4;
+    }
+
+    .clippy-bubble::after {
+        bottom: 1rem;
+    }
 }

--- a/js/clippy.js
+++ b/js/clippy.js
@@ -20,7 +20,9 @@ class Clippy {
     static isAllowedPageOrigin() {
         const h = window.location.hostname;
         if (h === 'localhost' || h === '127.0.0.1') return true;
-        return h === 'h3x89.github.io' || h === 'robertkubis.pl';
+        return (
+            h === 'h3x89.github.io' || h === 'robertkubis.pl' || h === 'www.robertkubis.pl'
+        );
     }
 
     initializeEventListeners() {

--- a/js/clippy.js
+++ b/js/clippy.js
@@ -24,10 +24,17 @@ class Clippy {
     }
 
     initializeEventListeners() {
-        // Show Clippy after 30 seconds
+        // `?showClippy=1` (or bare `showClippy`) helps QA on mobile without waiting 30s.
+        const params = new URLSearchParams(window.location.search);
+        const instant =
+            params.has('showClippy') &&
+            params.get('showClippy') !== '0' &&
+            params.get('showClippy') !== 'false';
+        const delayMs = instant ? 600 : 30000;
+
         this.showTimeout = setTimeout(() => {
             this.show();
-        }, 30000);
+        }, delayMs);
 
         // Hide Clippy when clicked
         this.clippy.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary

This PR is linked to h3x89/home_lab#43.

It adds a first responsive CSS pass for the assistant widget on mobile screens. I read the current `index.html`, `css/main.css`, and `js/clippy.js` and made the smallest likely-safe change: keep desktop behavior unchanged, then override only the assistant widget inside the existing `@media (max-width: 768px)` block.

## What changed

- Added mobile-only sizing for `.clippy-container`, `.clippy`, and `.clippy-bubble`.
- Uses `clamp(...)`, viewport width, max-width, and safe-area inset instead of one fixed phone-specific value.
- Keeps desktop styles as they are.
- Moves the active mobile assistant position to `right: 1rem` and makes the hidden state slide from outside the mobile viewport.

## Important note for the agent

I could not run visual/mobile tests from here. This PR should be treated as a good starting point, not as the final guaranteed pixel-perfect fix.

Please verify manually in browser/devtools before merging. It may need small tuning after real visual testing, especially around:

- exact duck size,
- speech bubble width,
- bottom offset on iPhone Safari,
- overlap with the hero terminal/buttons,
- whether the bubble should be hidden or simplified on very small screens.

## Test plan for agent

- Open the portfolio locally or via preview.
- Use mobile devtools widths around 390-430 px.
- Test a very narrow viewport around 360 px.
- Test desktop width to confirm the current nice large assistant is unchanged.
- Check that no horizontal scroll appears.
- Check the assistant while visible and while scrolling the hero section.

Closes h3x89/home_lab#43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes limited to responsive CSS for the assistant widget plus a small, opt-in URL param to shorten its display delay; primary risk is minor layout/positioning regressions on small viewports.
> 
> **Overview**
> Improves the mobile responsiveness of the Clippy assistant widget by overriding `.clippy-container`, `.clippy`, and `.clippy-bubble` styles under `@media (max-width: 768px)` (and further shrinking under `max-width: 400px`) using `clamp()`, viewport-based sizing, and safe-area-aware bottom spacing.
> 
> Adds a lightweight QA override in `clippy.js` so `?showClippy` can reduce the initial show delay (and expands the allowed origins list to include `www.robertkubis.pl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ade39ecec05eb05f5a7367e6f1889466662ca77a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->